### PR TITLE
Temporarily remove TS4900 CPU cores tests

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -127,36 +127,6 @@ ava.test.after.always(async () => {
   })
 })
 
-if (options.interactiveTests) {
-  // TODO: These should be tested as provisioning variants
-  // Allow the user to set image maker configuration options as env vars.
-  if (options.deviceType === 'ts4900') {
-    ava.test(`${options.deviceType}: Provision single model`, async (test) => {
-      return utils.runManualTestCase(test, {
-        do: [
-          'Go into an existing ts4900 app or create a new one',
-          'Select "single" as "CPU Cores"',
-          'Select any "Network Connection" option',
-          'Download the image and boot a single core variant of TS4900'
-        ],
-        assert: [ 'The device should successfully get provisioned and appear in dashboard' ]
-      })
-    })
-
-    ava.test(`${options.deviceType}: Provision quad model`, async (test) => {
-      return utils.runManualTestCase(test, {
-        do: [
-          'Go into an existing ts4900 app or create a new one',
-          'Select "quad" as "CPU Cores"',
-          'Select any "Network Connection" option',
-          'Download the image and boot a single core variant of TS4900'
-        ],
-        assert: [ 'The device should successfully get provisioned and appear in dashboard' ]
-      })
-    })
-  }
-}
-
 for (const testCase of [
   require('../tests/bluetooth-test'),
   require('../tests/device-online'),


### PR DESCRIPTION
We should re-make this as provisioning variants using image maker
options, which are not supported by the SDK at the moment.

See: https://github.com/resin-io/resinos-tests/issues/212
Change-Type: patch