### PR TITLE
Define OS concept

### DIFF
--- a/lib/components/os/resinos.js
+++ b/lib/components/os/resinos.js
@@ -18,16 +18,15 @@
 
 const Bluebird = require('bluebird')
 const imagefs = require('resin-image-fs')
+const {
+  join
+} = require('path')
 
 const utils = require('../../utils')
-
-exports.sshHostOS = async (command, uuid, privateKeyPath) => {
-  const options = [ '-p 22222', `root@${uuid}` ]
-  return utils.ssh(command, privateKeyPath, options)
-}
+const Resinio = require('../../components/resinio/sdk')
 
 // TODO: This function should be implemented using Reconfix
-exports.injectResinConfiguration = (image, configuration) => {
+const injectResinConfiguration = (image, configuration) => {
   return imagefs.writeFile({
     image,
     partition: 1,
@@ -36,7 +35,7 @@ exports.injectResinConfiguration = (image, configuration) => {
 }
 
 // TODO: This function should be implemented using Reconfix
-exports.injectNetworkConfiguration = (image, configuration) => {
+const injectNetworkConfiguration = (image, configuration) => {
   if (configuration.network === 'ethernet') {
     return Bluebird.resolve()
   }
@@ -70,4 +69,33 @@ exports.injectNetworkConfiguration = (image, configuration) => {
     partition: 1,
     path: '/system-connections/resin-wifi'
   }, wifiConfiguration.join('\n'))
+}
+
+module.exports = class ResinOS {
+  constructor (options = {}) {
+    this.options = options
+  }
+
+  get image () {
+    return join(this.options.tmpdir, 'resin.img')
+  }
+
+  async fetch () {
+    const resinio = new Resinio(this.options.url)
+
+    console.log(`Downloading device type OS into ${this.image}`)
+    await resinio.downloadDeviceTypeOS(this.options.deviceType, this.options.resinOSversion, this.image)
+  }
+
+  async configure () {
+    console.log(`Configuring resinOS image: ${this.image}`)
+    await injectResinConfiguration(this.image, this.options.configuration)
+    await injectNetworkConfiguration(this.image, this.options.configuration)
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async ssh (command, uuid, privateKeyPath) {
+    const options = [ '-p 22222', `root@${uuid}` ]
+    return utils.ssh(command, privateKeyPath, options)
+  }
 }

--- a/lib/components/resinio/sdk.js
+++ b/lib/components/resinio/sdk.js
@@ -48,6 +48,8 @@ module.exports = class ResinSDK {
     const stream = await this.resin.models.os.download(deviceType, version)
     // eslint-disable-next-line no-underscore-dangle
     const filename = stream.response.headers._headers['content-disposition'][0].split('"')[1]
+    const hardlink = path.join(path.dirname(destination), filename)
+
     if (!process.env.CI) {
       const bar = new visuals.Progress('Download')
       stream.on('progress', (data) => {
@@ -58,15 +60,15 @@ module.exports = class ResinSDK {
       })
     }
 
-    return new Bluebird((resolve, reject) => {
-      const output = fs.createWriteStream(destination)
+    await new Bluebird((resolve, reject) => {
+      const output = fs.createWriteStream(hardlink)
       output.on('error', reject)
       stream.on('error', reject)
-      stream.on('finish', () => {
-        resolve(filename)
-      })
+      stream.on('finish', resolve)
       stream.pipe(output)
     })
+
+    await fs.symlinkAsync(hardlink, destination)
   }
 
   getApplicationOSConfiguration (application, options) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,9 +18,9 @@
 
 const _ = require('lodash')
 const AJV = require('ajv')
+const Bluebird = require('bluebird')
 const fse = require('fs-extra')
-const fs = require('fs')
-const path = require('path')
+const fs = Bluebird.promisifyAll(require('fs'))
 const Store = require('data-store')
 
 const QEMUWorker = require('./workers/qemu')
@@ -36,7 +36,7 @@ fse.ensureDirSync(options.tmpdir)
 
 const utils = require('./utils')
 const Resinio = utils.requireComponent('resinio', 'sdk')
-const resinos = utils.requireComponent('resinos', 'default')
+const Resinos = utils.requireComponent('os', 'resinos')
 const deviceTypeContract = require(`../contracts/contracts/hw.device-type/${options.deviceType}.json`)
 
 const resinio = new Resinio(options.resinUrl)
@@ -46,7 +46,8 @@ const context = {
   key: null,
   dashboardUrl: null,
   gitUrl: null,
-  filename: null,
+  os: null,
+  worker: null,
   deviceType: deviceTypeContract
 }
 
@@ -69,11 +70,6 @@ const setup = async () => {
 
   context.key = await resinio.createSSHKey(options.sshKeyLabel)
   console.log(`Add new SSH key: ${context.key.publicKey} with label: ${options.sshKeyLabel}`)
-
-  console.log(`Downloading device type OS into ${imagePath}`)
-  const downloadResinio = new Resinio(options.resinStagingUrl)
-  context.filename = await downloadResinio.downloadDeviceTypeOS(options.deviceType, options.resinOSVersion, imagePath)
-
   if (options.delta) {
     console.log('Enabling deltas')
     await resinio.createEnvironmentVariable(options.applicationName, 'RESIN_SUPERVISOR_DELTA', options.delta)
@@ -86,23 +82,30 @@ const setup = async () => {
   const resinConfiguration = await resinio.getDeviceOSConfiguration(
     placeholder.uuid, placeholder.deviceApiKey, _.assign({
       version: options.resinOSVersion
-    }, options.configuration))
+    }, options.configuration)
+  )
 
-  console.log(`Injecting resin.io configuration into ${imagePath}`)
-  await resinos.injectResinConfiguration(imagePath, resinConfiguration)
+  context.os = new Resinos({
+    tmpdir: options.tmpdir,
+    configuration: resinConfiguration,
+    deviceType: options.deviceType,
+    version: options.resinOSVersion,
+    url: options.resinStagingUrl
+  })
 
-  console.log(`Injecting network configuration into ${imagePath}`)
-  await resinos.injectNetworkConfiguration(imagePath, options.configuration)
+  await context.os.fetch()
 
-  context.worker = options.deviceType === 'qemux86-64'
-    ? new QEMUWorker('main worker', deviceTypeContract)
-    : new ManualWorker('main worker', deviceTypeContract, {
+  // FIXME this should be extracted out
+  if (options.deviceType === 'qemux86-64') {
+    context.worker = new QEMUWorker('main worker', deviceTypeContract)
+  } else {
+    context.worker = new ManualWorker('main worker', deviceTypeContract, {
       devicePath: options.disk
     })
+  }
 
-  console.log(`Flashing ${imagePath}`)
   await context.worker.ready()
-  await context.worker.flash(imagePath)
+  await context.worker.flash(context.os)
   await context.worker.on()
 
   console.log('Waiting while device boots')
@@ -121,7 +124,7 @@ const setup = async () => {
   })
 
   console.log('Gathering metrics')
-  results.imageSize = `${fs.statSync(imagePath).size / 1048576.0} Mb`
+  results.imageSize = `${(await fs.statAsync(await fs.realpathAsync(context.os.image))).size / 1048576.0} Mb`
   results.provisionTime = `${Math.floor(uptime / 60)}m ${Math.floor(uptime % 60)}s`
   results.email = await resinio.getEmail()
 

--- a/lib/workers/manual.js
+++ b/lib/workers/manual.js
@@ -32,10 +32,13 @@ module.exports = class ManualWorker {
 
   // eslint-disable-next-line class-methods-use-this
   async ready () {
-    return Bluebird.resolve()
+    console.log('Worker is ready')
   }
 
-  async flash (image) {
+  async flash (os) {
+    await os.configure()
+
+    console.log(`Flashing ${os.image}`)
     const drives = await drivelist.listAsync()
     const destination = this.options.devicePath
     const drive = _.find(drives, {
@@ -48,21 +51,21 @@ module.exports = class ManualWorker {
 
     await mountutils.unmountDiskAsync(drive.device)
     const driveFileDescriptor = await fs.openAsync(drive.raw, 'rs+')
-    const imageSize = await fs.statAsync(image).get('size')
+    const imageSize = await fs.statAsync(os.image).get('size')
 
     const emitter = imageWrite.write({
       fd: driveFileDescriptor,
       device: drive.raw,
       size: drive.size
     }, {
-      stream: fs.createReadStream(image),
+      stream: fs.createReadStream(os.image),
       size: imageSize
     }, {
       check: true
     })
 
     emitter.on('progress', (state) => {
-      console.log(`Flashing ${image}: ${state.percentage.toFixed(2)}% (${state.type})`)
+      console.log(`Flashing ${os.image}: ${state.percentage.toFixed(2)}% (${state.type})`)
     })
 
     await new Bluebird((resolve, reject) => {

--- a/lib/workers/qemu.js
+++ b/lib/workers/qemu.js
@@ -16,7 +16,6 @@
 
 'use strict'
 
-const Bluebird = require('bluebird')
 const childProcess = require('child_process')
 
 const childKillEventHandler = (child, event) => {
@@ -27,19 +26,22 @@ const childKillEventHandler = (child, event) => {
 }
 
 module.exports = class QEMUWorker {
-  constructor (title, deviceType) {
+  constructor (title, deviceType, options = {}) {
     this.title = title
     this.deviceType = deviceType
+    this.options = options
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async ready () {
-    return Bluebird.resolve()
+  async ready (os) {
+    console.log('Worker is ready')
   }
 
-  async flash (image) {
-    console.log(`Image ${image} is ready to use`)
-    this.image = image
+  async flash (os) {
+    await os.configure()
+
+    console.log(`Flashing ${os.image}`)
+    this.image = os.image
   }
 
   async on () {

--- a/tests/os-file-format.js
+++ b/tests/os-file-format.js
@@ -16,13 +16,22 @@
 
 'use strict'
 
+const Bluebird = require('bluebird')
+const realpath = Bluebird.promisify(require('fs').realpath)
+
+const {
+  basename
+} = require('path')
+
 module.exports = {
   title: 'Image filename format',
   run: async (test, context, options, components) => {
     const supervisorVersion = await components.resinio.getSupervisorVersion(context.uuid)
     const hostOsVersion = (await components.resinio.getDeviceHostOSVersion(context.uuid)).split(' ')
     const apiUrl = (await components.resinio.getApiUrl()).split('.')
-    test.is(context.filename, `${apiUrl[1]}-${options.deviceType}-${hostOsVersion[2]}-v${supervisorVersion}.img`)
+    const filename = basename(await realpath(context.os.image))
+    test.is(filename, `${apiUrl[1]}-${options.deviceType}-${hostOsVersion[2]}-v${supervisorVersion}.img`)
     test.end()
+    test.is(filename, `${apiUrl[1]}-${options.deviceType}-${hostOsVersion[2]}-v${supervisorVersion}.img`)
   }
 }


### PR DESCRIPTION
Create OS component which provides the required configuration to run a specific OS.
This class will be closely related (coupled) to the worker class. The ready method in the
worker class will use OS class to fetch and configure the image.
The two interfaces should be kept in sync.
We need for this component when trying to configure an OS which is specific to the OS
but must executed by the worker. If this component would not exists OS specific code
would exist in the worker.

Signed-off-by: Theodor Gherzan <theodor@resin.io>