### PR TITLE
Add kvm support to speed qemu up

### DIFF
--- a/lib/workers/qemu.js
+++ b/lib/workers/qemu.js
@@ -53,7 +53,7 @@ module.exports = class QEMUWorker {
       '-net', 'user',
       '-m', '512',
       '-nographic',
-      '-machine', 'type=pc',
+      '-machine', 'type=pc,accel=kvm',
       '-smp', '4'
     ])
 


### PR DESCRIPTION
Without kvm qemu does not connects the vpn

Signed-off-by: Theodor Gherzan <theodor@resin.io>