### PR TITLE
ResinIO ssh connection requires a certain device state

### DIFF
--- a/lib/components/resinio/sdk.js
+++ b/lib/components/resinio/sdk.js
@@ -21,6 +21,7 @@ const Bluebird = require('bluebird')
 const path = require('path')
 const visuals = require('resin-cli-visuals')
 const os = require('os')
+const semver = require('resin-semver')
 
 const fs = Bluebird.promisifyAll(require('fs'))
 const keygen = Bluebird.promisify(require('ssh-keygen'))
@@ -35,8 +36,14 @@ module.exports = class ResinSDK {
   }
 
   async sshHostOS (command, uuid, privateKeyPath) {
+    const VERSION_REQUIREMENT = '2.7.5'
     const SSH_HOST = 'ssh.resindevice.io'
     const options = [ '-p 22', `${await this.resin.auth.whoami()}@${SSH_HOST}`, `host -s ${uuid}` ]
+
+    await utils.waitUntil(async () => {
+      return await this.isDeviceOnline(uuid) && semver.gte(await this.getDeviceHostOSVersion(uuid), VERSION_REQUIREMENT)
+    })
+
     return utils.ssh(command, privateKeyPath, options)
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -107,11 +107,6 @@ const setup = async () => {
   })
   context.uuid = placeholder.uuid
 
-  console.log('Waiting while supervisor starts')
-  await utils.waitUntil(async () => {
-    return await resinio.getDeviceStatus(placeholder.uuid) === 'Idle'
-  })
-
   const uptime = await utils.getDeviceUptime((command) => {
     return resinio.sshHostOS(command, context.uuid, context.key.privateKeyPath)
   })


### PR DESCRIPTION
HostOS verison to be greater than 2.7.5 and the device to be connected to the vpn

Change-type: patch
Signed-off-by: Theodor Gherzan <theodor@resin.io>