### PR TITLE
Update package.json for new resin-semver release

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,3 +63,4 @@
     "eslint-plugin-standard": "^3.0.1"
   }
 }
+


### PR DESCRIPTION
This repo is one of the 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)